### PR TITLE
🧪 add tests for getStringFlag utility function

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestGetStringFlag(t *testing.T) {
+	tests := []struct {
+		name          string
+		flagName      string
+		setupCmd      func() *cobra.Command
+		expectedValue string
+		expectError   bool
+	}{
+		{
+			name:     "valid flag",
+			flagName: "test-flag",
+			setupCmd: func() *cobra.Command {
+				cmd := &cobra.Command{}
+				cmd.Flags().String("test-flag", "test-value", "")
+				return cmd
+			},
+			expectedValue: "test-value",
+			expectError:   false,
+		},
+		{
+			name:     "empty flag",
+			flagName: "test-flag",
+			setupCmd: func() *cobra.Command {
+				cmd := &cobra.Command{}
+				cmd.Flags().String("test-flag", "", "")
+				return cmd
+			},
+			expectedValue: "",
+			expectError:   false,
+		},
+		{
+			name:     "missing flag",
+			flagName: "non-existent",
+			setupCmd: func() *cobra.Command {
+				return &cobra.Command{}
+			},
+			expectedValue: "",
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := tt.setupCmd()
+			got, err := getStringFlag(tt.flagName, cmd)
+			if (err != nil) != tt.expectError {
+				t.Errorf("getStringFlag() error = %v, expectError %v", err, tt.expectError)
+				return
+			}
+			if got != tt.expectedValue {
+				t.Errorf("getStringFlag() = %v, expected %v", got, tt.expectedValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
The `getStringFlag` utility function in `cmd/root.go` was previously untested. This PR adds comprehensive unit tests for this function.

### 📊 Coverage: What scenarios are now tested
- **Valid flag**: Verifies that a correctly set string flag returns the expected value.
- **Empty flag**: Ensures that a flag set to an empty string is handled correctly.
- **Missing flag**: Confirms that attempting to retrieve a non-existent flag returns an error, as expected by the function's signature.

### ✨ Result: The improvement in test coverage
- Added `cmd/root_test.go` with `TestGetStringFlag`.
- Improved reliability of flag parsing logic by ensuring the utility function behaves correctly across different states of the `cobra.Command`.
- Local test execution was attempted but bypassed due to environment-specific network timeouts during dependency resolution; final verification will be handled by CI.

---
*PR created automatically by Jules for task [16054697126405981217](https://jules.google.com/task/16054697126405981217) started by @damacus*